### PR TITLE
Add FMT_HEADER_ONLY compile definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ set(CMAKE_MESSAGE_CONTEXT_SHOW ON CACHE BOOL "Show CMake message context")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+add_definitions(-DFMT_HEADER_ONLY)
+
 include(AsamCommonUtils)
 setup_repo(${REPO_OPTION_PREFIX})
 


### PR DESCRIPTION
To be able to run modules on Ubuntu in python