### PR TITLE
Other/update to opendaq 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.25)
 set(REPO_NAME asam_cmp_modules)
 set(REPO_OPTION_PREFIX ASAM_CMP)
 
+if (MSVC)
+    add_compile_options(/bigobj)
+endif()
+
 project(${REPO_NAME} VERSION 1.0.0)
 
 if (POLICY CMP0135)

--- a/asam_cmp_capture_module/tests/CMakeLists.txt
+++ b/asam_cmp_capture_module/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(TEST_HEADERS
 
 if (MSVC)
     add_compile_options(/bigobj)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4459>)
 endif()
 
 

--- a/asam_cmp_data_sink/tests/CMakeLists.txt
+++ b/asam_cmp_data_sink/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ set(TEST_SOURCES test_app.cpp
 
 if (MSVC)
     add_compile_options(/bigobj)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4459>)
 endif()
 
 add_executable(${TEST_APP} ${TEST_SOURCES}

--- a/asam_cmp_data_sink/tests/test_stream_fb.cpp
+++ b/asam_cmp_data_sink/tests/test_stream_fb.cpp
@@ -649,7 +649,7 @@ protected:
     std::shared_ptr<Packet> createEthernetPacket()
     {
         EthernetPayload ethernetPayload;
-        ethernetPayload.setData(binaryData.data(), binaryData.size());
+        ethernetPayload.setData(binaryData.data(), (uint16_t)binaryData.size());
 
         ethernetPacket = std::make_shared<Packet>();
         ethernetPacket->setPayload(ethernetPayload);

--- a/asam_cmp_example/CMakeLists.txt
+++ b/asam_cmp_example/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_executable(asam_cmp_modules_example main.cpp)
 
+if (MSVC)
+    add_compile_options(/bigobj)
+endif()
+
 target_link_libraries(asam_cmp_modules_example PRIVATE
     daq::opendaq
 )

--- a/external/openDAQ/CMakeLists.txt
+++ b/external/openDAQ/CMakeLists.txt
@@ -3,10 +3,10 @@ set(OPENDAQ_ENABLE_TESTS false)
 FetchContent_Declare(
     openDAQ
     GIT_REPOSITORY https://github.com/openDAQ/openDAQ.git
-    GIT_TAG        14b647f955078e7d146513cfb2edc24a675fe679
+    GIT_TAG        v3.20.2
     GIT_PROGRESS   ON
     SYSTEM
-    FIND_PACKAGE_ARGS 3.0.0 GLOBAL
+    FIND_PACKAGE_ARGS 3.20.2 GLOBAL
 )
 
 FetchContent_MakeAvailable(openDAQ)


### PR DESCRIPTION
# Brief

Updated ASAM-CMP-Module to openDAQ 3.20.

# Description

Updated the repository to be compliant with openDAQ 3.20. Also fixed a warning and added an ignore warnings for overwrite of (Warning C4459)[https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4459?view=msvc-170] to help with easier compilation of the entire repository.

# Usage example

n/a

# Required application changes

The application needs to be complient with (openDAQ v3.20.2)[https://github.com/openDAQ/openDAQ/tree/v3.20.2]