### PR TITLE
Update the project to compile with the latest opendaq

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,15 +47,12 @@ if (MSVC)
     add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4100>)
 endif()
 
-add_definitions(-DFMT_HEADER_ONLY)
+add_compile_definitions(FMT_HEADER_ONLY)
 
 if (${REPO_OPTION_PREFIX}_ENABLE_EXAMPLE)
     set(DAQMODULES_REF_DEVICE_MODULE ON)
     set(DAQMODULES_REF_FB_MODULE ON)
 endif()
-
-# TODO: move add_subdirectory(external) after openDAQ SDK fetch once TBBAS-3072 is resolved
-add_subdirectory(external)
 
 if (NOT TARGET "${OPENDAQ_SDK_TARGET_NAMESPACE}::${OPENDAQ_SDK_TARGET_NAME}")
     if (PROJECT_IS_TOP_LEVEL)
@@ -82,6 +79,7 @@ if (NOT TARGET "${OPENDAQ_SDK_TARGET_NAMESPACE}::${OPENDAQ_SDK_TARGET_NAME}")
     endif()
 endif()
 
+add_subdirectory(external)
 add_subdirectory(shared)
 add_subdirectory(modules)
 if (${REPO_OPTION_PREFIX}_ENABLE_EXAMPLE)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,12 +1,14 @@
 set(CMAKE_FOLDER "cmake")
+
 list(APPEND CMAKE_MESSAGE_CONTEXT cmake)
+set(CURR_MESSAGE_CONTEXT ${CMAKE_MESSAGE_CONTEXT})
 
 message(STATUS "Import functions and macro from opendaq-cmake-utils repo")
 include(FetchContent)
 FetchContent_Declare(
     opendaq-cmake-utils
-    GIT_REPOSITORY https://github.com/openDAQ/opendaq-cmake-utils.git
-    GIT_TAG v1.0.0
-    GIT_PROGRESS ON
+    GIT_REPOSITORY  https://github.com/openDAQ/opendaq-cmake-utils.git
+    GIT_TAG         v1.0.1
+    GIT_PROGRESS    ON
 )
 FetchContent_MakeAvailable(opendaq-cmake-utils)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,10 +1,19 @@
+opendaq_get_cmake_mode(_ASAM_CMP_CMAKE_MODERN_MODE_SAVED)
+opendaq_set_cmake_mode(ANCIENT)
+
 set(CMAKE_FOLDER external)
 list(APPEND CMAKE_MESSAGE_CONTEXT external)
 
 if (${REPO_OPTION_PREFIX}_ENABLE_TESTS AND NOT TARGET gtest)
     set(BUILD_GMOCK ON)
     opendaq_module_setup_gtest(1.12.1)
+
+    get_target_property(GTEST_INCLUDE_DIRS gtest INTERFACE_INCLUDE_DIRECTORIES)
+    target_include_directories(gmock PRIVATE ${GTEST_INCLUDE_DIRS})
+    target_include_directories(gmock_main PRIVATE ${GTEST_INCLUDE_DIRS})
 endif()
 
 add_subdirectory(PcapPlusPlus)
 add_subdirectory(AsamCmpLib)
+
+opendaq_set_cmake_mode(${_ASAM_CMP_CMAKE_MODERN_MODE_SAVED})

--- a/modules/asam_cmp_capture_module/src/capture_fb.cpp
+++ b/modules/asam_cmp_capture_module/src/capture_fb.cpp
@@ -19,9 +19,9 @@ CaptureFb::CaptureFb(const ModuleInfoPtr& moduleInfo,
     , ethernetWrapper(init.ethernetWrapper)
     , selectedEthernetDeviceName(init.selectedDeviceName)
 {
+    initStatusPacket();
     initProperties();
     initEncoders();
-    initStatusPacket();
     startStatusLoop();
 }
 
@@ -33,14 +33,16 @@ CaptureFb::~CaptureFb()
 void CaptureFb::initProperties()
 {
     initDeviceInfoProperties(false);
+    objPtr.beginUpdate();
     deviceDescription = "DefaultDeviceDescription";
-    setPropertyValueInternal(String("DeviceDescription").asPtr<IString>(true), deviceDescription, false, false, false);
+    objPtr.setPropertyValue("DeviceDescription", deviceDescription);
     serialNumber = "DefaultSerialNumber";
-    setPropertyValueInternal(String("SerialNumber").asPtr<IString>(true), serialNumber, false, false, false);
+    objPtr.setPropertyValue("SerialNumber", serialNumber);
     hardwareVersion = "DefaultHardwareVersion";
-    setPropertyValueInternal(String("HardwareVersion").asPtr<IString>(true), hardwareVersion, false, false, false);
+    objPtr.setPropertyValue("HardwareVersion", hardwareVersion);
     softwareVersion = "DefaultSoftwareVersion";
-    setPropertyValueInternal(String("SoftwareVersion").asPtr<IString>(true), softwareVersion, false, false, false);
+    objPtr.setPropertyValue("SoftwareVersion", softwareVersion);
+    objPtr.endUpdate();
 }
 
 void CaptureFb::propertyChanged()

--- a/modules/asam_cmp_capture_module/src/stream_fb.cpp
+++ b/modules/asam_cmp_capture_module/src/stream_fb.cpp
@@ -140,14 +140,12 @@ void StreamFb::configureScaledAnalogSignal()
     analogDataSampleDt = postScaling.getInputSampleType() == SampleType::Int16 ? 16 : 32;
     analogDataHasInternalPostScaling = false;
 
-    setPropertyValueInternal(
-        String("Scale").asPtr<IString>(true), BaseObjectPtr(analogDataScale).asPtr<IBaseObject>(true), false, true, false);
-
-    setPropertyValueInternal(
-        String("Offset").asPtr<IString>(true), BaseObjectPtr(analogDataOffset).asPtr<IBaseObject>(true), false, true, false);
-
-    setPropertyValueInternal(
-        String("IsClientPostScaling").asPtr<IString>(true), BaseObjectPtr(true).asPtr<IBaseObject>(true), false, true, false);
+    PropertyObjectProtectedPtr objPtrProtected = objPtr.asPtr<IPropertyObjectProtected>(true);
+    objPtr.beginUpdate();
+    objPtrProtected.setProtectedPropertyValue("Scale", analogDataScale);
+    objPtrProtected.setProtectedPropertyValue("Offset", analogDataOffset);
+    objPtrProtected.setProtectedPropertyValue("IsClientPostScaling", true);
+    objPtr.endUpdate();
 }
 
 void StreamFb::configureMinMaxAnalogSignal()
@@ -189,20 +187,17 @@ void StreamFb::configureMinMaxAnalogSignal()
         analogDataHasInternalPostScaling = true;
     }
 
-    setPropertyValueInternal(
-        String("MinValue").asPtr<IString>(true), BaseObjectPtr(analogDataMin).asPtr<IBaseObject>(true), false, true, false);
-
-    setPropertyValueInternal(
-        String("MaxValue").asPtr<IString>(true), BaseObjectPtr(analogDataMax).asPtr<IBaseObject>(true), false, true, false);
-
-    setPropertyValueInternal(
-        String("IsClientPostScaling").asPtr<IString>(true), BaseObjectPtr(false).asPtr<IBaseObject>(true), false, true, false);
+    PropertyObjectProtectedPtr objPtrProtected = objPtr.asPtr<IPropertyObjectProtected>(true);
+    objPtr.beginUpdate();
+    objPtrProtected.setProtectedPropertyValue("MinValue", analogDataMin);
+    objPtrProtected.setProtectedPropertyValue("MaxValue", analogDataMax);
+    objPtrProtected.setProtectedPropertyValue("IsClientPostScaling", false);
+    objPtr.endUpdate();
 }
 
 void StreamFb::onAnalogSignalConnected()
 {
-    setPropertyValueInternal(
-        String("IsConnectedAnalogSignal").asPtr<IString>(true), BaseObjectPtr(true).asPtr<IBaseObject>(true), false, true, false);
+    objPtr.asPtr<IPropertyObjectProtected>(true).setProtectedPropertyValue("IsConnectedAnalogSignal", true);
 
     constexpr double invertedTickResolution = 1'000'000;
     int64_t delta = inputDomainDataDescriptor.getRule().getParameters().get("delta");
@@ -220,8 +215,7 @@ void StreamFb::onAnalogSignalConnected()
 
 void StreamFb::onAnalogSignalDisconnected()
 {
-    setPropertyValueInternal(
-        String("IsConnectedAnalogSignal").asPtr<IString>(true), BaseObjectPtr(false).asPtr<IBaseObject>(true), false, true, false);
+    objPtr.asPtr<IPropertyObjectProtected>(true).setProtectedPropertyValue("IsConnectedAnalogSignal", false);
 }
 
 void StreamFb::onDisconnected(const InputPortPtr& inputPort)
@@ -236,7 +230,7 @@ void StreamFb::onDisconnected(const InputPortPtr& inputPort)
 
 void StreamFb::onPacketReceived(const InputPortPtr& port)
 {
-    auto lock = this->getAcquisitionLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     PacketPtr packet;
     const auto connection = inputPort.getConnection();

--- a/modules/asam_cmp_capture_module/tests/test_analog_messages.cpp
+++ b/modules/asam_cmp_capture_module/tests/test_analog_messages.cpp
@@ -194,7 +194,7 @@ void AnalogMessagesTest::testAnalogPackets(bool setScale)
 
     size_t timeElapsed = 0;
     auto stTime = std::chrono::steady_clock::now();
-    while (!checker() && timeElapsed < 2500'000'000)
+    while (!checker() && timeElapsed < 60'000)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
         auto curTime1 = std::chrono::steady_clock::now();

--- a/shared/libraries/asam_cmp_common_lib/src/interface_common_fb.cpp
+++ b/shared/libraries/asam_cmp_common_lib/src/interface_common_fb.cpp
@@ -93,11 +93,7 @@ void InterfaceCommonFb::updatePayloadTypeInternal()
 
     if (newType < 0 || static_cast<size_t>(newType) > maxPayloadIndex())
     {
-        setPropertyValueInternal(String("PayloadType").asPtr<IString>(true),
-                                 BaseObjectPtr(payloadTypeToIndex(payloadType.getType())).asPtr<IBaseObject>(true),
-                                 false,
-                                 false,
-                                 false);
+        objPtr.setPropertyValue("PayloadType", payloadTypeToIndex(payloadType.getType()));
     }
     else
     {

--- a/shared/libraries/asam_cmp_common_lib/src/network_manager_fb.cpp
+++ b/shared/libraries/asam_cmp_common_lib/src/network_manager_fb.cpp
@@ -54,7 +54,7 @@ void NetworkManagerFb::networkAdapterChangedInternal()
     int oldInd = objPtr.getPropertyValue("NetworkAdaptersNames");
     int newInd = objPtr.getPropertyValue("NetworkAdapters");
 
-    setPropertyValueInternal(String("NetworkAdaptersNames"), BaseObjectPtr(newInd), false, false, false);
+    objPtr.setPropertyValue("NetworkAdaptersNames", newInd);
     StringPtr newName = objPtr.getPropertySelectionValue("NetworkAdaptersNames");
 
     if (ethernetWrapper->setDevice(newName))
@@ -63,8 +63,8 @@ void NetworkManagerFb::networkAdapterChangedInternal()
     }
     else
     {
-        setPropertyValueInternal(String("NetworkAdaptersNames"), BaseObjectPtr(oldInd), false, false, false);
-        setPropertyValueInternal(String("NetworkAdapters"), BaseObjectPtr(oldInd), false, false, false);
+        objPtr.setPropertyValue("NetworkAdaptersNames", oldInd);
+        objPtr.setPropertyValue("NetworkAdapters", oldInd);
     }
 }
 


### PR DESCRIPTION
- In the latest opendaq the method setPropertyValueInternal was moved to the private scope. this pr is replacing using of it to the method setPropertyValue / setProtectedPropertyValue 
- Updating the opendaq-cmake-utils from v1.0.0 to v1.0.1