### PR TITLE
Update README prerequisites section (Npcap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It uses [PcapPlusPlus Library](https://pcapplusplus.github.io/) to transport CMP
 - Gather information about Capture Modules appearing on the network.
 
 ## Prerequisites
-On Windows, [Npcap](https://npcap.com/#download) must be installed with the **"Install Npcap in WinPcap API-compatible Mode"** option enabled. This option makes the packet-capture libraries (`wpcap.dll`, `packet.dll`) available system-wide, so the modules can locate them.
+On Windows, [Npcap](https://npcap.com/#download) must be installed with the **"Install Npcap in WinPcap API-compatible Mode"** option enabled. This option makes the packet-capture libraries (`wpcap.dll`, `packet.dll`) available system-wide, so the modules can locate them. If Npcap is already installed without this option, reinstall it with the option enabled.
 
 ## Required tools before building
  - [CMake 3.24](https://cmake.org/) or higher

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ It uses [PcapPlusPlus Library](https://pcapplusplus.github.io/) to transport CMP
 - Support CAN / CAN-FD and Analog signals.
 - Gather information about Capture Modules appearing on the network.
 
+## Prerequisites
+On Windows, [Npcap](https://npcap.com/#download) must be installed with the **"Install Npcap in WinPcap API-compatible Mode"** option enabled. This option makes the packet-capture libraries (`wpcap.dll`, `packet.dll`) available system-wide, so the modules can locate them.
+
 ## Required tools before building
  - [CMake 3.24](https://cmake.org/) or higher
  - [Git](https://git-scm.com/)
  - libpcap
-    - [Npcap](https://npcap.com/#download) for Windows  
-      must be installed in WinPcap API-compatible Mode
+    - [Npcap](https://npcap.com/#download) for Windows (see [Prerequisites](#prerequisites))
     - [libpcap developers pack](https://www.tcpdump.org/#latest-release) for Linux  
       can be installed through a package manager `sudo apt-get install libpcap-dev`
  - Compiler:


### PR DESCRIPTION
# Brief

Add a Prerequisites section to the README so Npcap reads as a dependency of the module (runtime and build), not just a build tool.

# Description

The modules depend on the packet-capture libraries `wpcap.dll` and `packet.dll`, which are shipped with Npcap.

On Windows, when Npcap is installed, these libraries are placed by default into `C:\Windows\System32\Npcap\`, which is not on the standard DLL search path — so when a module is loaded, the system cannot find them and loading fails. To make the libraries available system-wide (in `C:\Windows\System32\`), the **"Install Npcap in WinPcap API-compatible Mode"** option must be enabled during installation.

This information was present in the README, but only under the section related to building, whereas it is equally required at runtime. To remove this ambiguity, a dedicated **Prerequisites** section was added covering both the runtime and build use cases.
